### PR TITLE
Fix tests

### DIFF
--- a/atlas_of_innovation/__init__.py
+++ b/atlas_of_innovation/__init__.py
@@ -2,7 +2,7 @@ from pyramid.config import Configurator
 
 from sqlalchemy import engine_from_config
 
-from .models.example import DBSession, Base
+from .models.meta import DBSession, Base
 
 
 def main(global_config, **settings):
@@ -13,7 +13,7 @@ def main(global_config, **settings):
     DBSession.configure(bind=engine)
     Base.metadata.bind = engine
 
-    config = Configurator(settings=settings, root_factory='atlas_of_innovation.models.example.Root')
+    config = Configurator(settings=settings)
     config.include('pyramid_mako')
     config.include('.models')
 

--- a/atlas_of_innovation/tests/API_tests.py
+++ b/atlas_of_innovation/tests/API_tests.py
@@ -8,7 +8,7 @@ def dummy_request(dbsession):
 
 
 class APITests(unittest.TestCase):
-    def init_database(self):
+    def init_database(self, settings_file):
         from atlas_of_innovation.models.meta import Base
         session_factory = self.config.registry['dbsession_factory']
         engine = session_factory.kw['bind']
@@ -17,11 +17,12 @@ class APITests(unittest.TestCase):
         Base.metadata.create_all(engine)
 
         from atlas_of_innovation.models import reset_db
-        reset_db.main(argv=["reset_db", self.config.get_settings()['__file__'], "atlas_of_innovation/tests/test_spaces.csv"])
+        reset_db.main(argv=["reset_db", settings_file, "atlas_of_innovation/tests/test_spaces.csv"])
 
     def setUp(self):
         from pyramid.paster import get_appsettings
-        settings = get_appsettings('pytest.ini', name='main')
+        settings_file = "pytest.ini"
+        settings = get_appsettings(settings_file, name='main')
         from atlas_of_innovation.models import get_tm_session
         self.config = testing.setUp(settings=settings)
 
@@ -35,7 +36,7 @@ class APITests(unittest.TestCase):
 
         session_factory = self.config.registry['dbsession_factory']
         self.session = get_tm_session(session_factory, transaction.manager)
-        self.init_database()
+        self.init_database(settings_file)
 
     def tearDown(self):
         testing.tearDown()


### PR DESCRIPTION
Apparently self.config.get_settings() got cleaned up so that it doesn't include some self-referential metadata anymore, including __file__, which I was using. This reverts to hardcoding it instead of relying on the config object itself to keep track of it. 